### PR TITLE
Changed the type of LogEntry.body from String to Body

### DIFF
--- a/src/rekor/apis/entries_api.rs
+++ b/src/rekor/apis/entries_api.rs
@@ -14,6 +14,7 @@ use super::{configuration, Error};
 use crate::rekor::apis::ResponseContent;
 use crate::rekor::models::log_entry::LogEntry;
 use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 
 /// struct for typed errors of method [`create_log_entry`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -93,7 +94,7 @@ pub async fn create_log_entry(
     let local_var_content = local_var_resp.text().await?;
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
-        serde_json::from_str::<LogEntry>(&(parse_response(local_var_content))).map_err(Error::from)
+        LogEntry::from_str(&(parse_response(local_var_content))).map_err(Error::from)
     } else {
         let local_var_entity: Option<CreateLogEntryError> =
             serde_json::from_str(&local_var_content).ok();
@@ -130,7 +131,7 @@ pub async fn get_log_entry_by_index(
     let local_var_content = local_var_resp.text().await?;
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
-        serde_json::from_str::<LogEntry>(&(parse_response(local_var_content))).map_err(Error::from)
+        LogEntry::from_str(&(parse_response(local_var_content))).map_err(Error::from)
     } else {
         let local_var_entity: Option<GetLogEntryByIndexError> =
             serde_json::from_str(&local_var_content).ok();
@@ -170,7 +171,7 @@ pub async fn get_log_entry_by_uuid(
     let local_var_content = local_var_resp.text().await?;
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
-        serde_json::from_str::<LogEntry>(&(parse_response(local_var_content))).map_err(Error::from)
+        LogEntry::from_str(&(parse_response(local_var_content))).map_err(Error::from)
     } else {
         let local_var_entity: Option<GetLogEntryByUuidError> =
             serde_json::from_str(&local_var_content).ok();

--- a/src/rekor/models/hashedrekord.rs
+++ b/src/rekor/models/hashedrekord.rs
@@ -37,7 +37,7 @@ impl Hashedrekord {
 }
 
 /// Stores the Signature and Data struct
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Spec {
     pub signature: Signature,
@@ -52,7 +52,7 @@ impl Spec {
 }
 
 /// Stores the signature format, signature of the artifact and the PublicKey struct
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Signature {
     pub content: String,
@@ -69,7 +69,7 @@ impl Signature {
 }
 
 /// Stores the public key used to sign the artifact
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PublicKey {
     content: String,
@@ -86,7 +86,7 @@ impl PublicKey {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Data {
     pub hash: Hash,
@@ -98,15 +98,16 @@ impl Data {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[allow(non_camel_case_types)]
 pub enum AlgorithmKind {
+    #[default]
     sha256,
     sha1,
 }
 
 /// Stores the algorithm used to hash the artifact and the value of the hash
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Hash {
     pub algorithm: AlgorithmKind,


### PR DESCRIPTION
Objective
To enable detailed information of LogEntry.body to be obtained when LogEntry is retrieved. Change
In conjunction with changing the type of LogEntry.body to Body, I added default trait for Body and the structs and enums on which it depends, using derive macro.
 (Body, Spec, Signature, PublicKey, Data, AlgotithmKind, Hash)
In addition, in entries_api.rs, the use of serde_json::from_str was changed to the newly implemented LogEntry::from_str. LogEntry::from_str uses HashMap with &str for key and serde_json::Value for value, and body is decoded. Since a HashMap cannot be directly converted to a LogEntry, it is converted to a String with serde_json::to_string and then converted to a LogEntry with serde_json::from_str.

Signed-off-by: Neccolini <shun11202991@gmail.com>